### PR TITLE
add size caculate beyond sizeCache bound

### DIFF
--- a/UICollectionView+ARDynamicHeightLayoutCell/UICollectionView+ARDynamicCacheHeightLayoutCell.m
+++ b/UICollectionView+ARDynamicHeightLayoutCell/UICollectionView+ARDynamicCacheHeightLayoutCell.m
@@ -199,8 +199,14 @@ typedef NS_ENUM(NSUInteger, ARDynamicSizeCaculateType) {
 {
     BOOL hasCache = NO;
     if ([self sizeCache].count > indexPath.section) {
-        if ([[self sizeCache][indexPath.section] count] > indexPath.row) {
+        NSMutableArray *section = [self sizeCache][indexPath.section];
+        if (section.count > indexPath.row) {
             hasCache = YES;
+        }
+        else {
+            for (unsigned int index = 0; index < indexPath.row - section.count + 1; index++) {
+                [section addObject:[NSValue valueWithCGSize:CGSizeZero]];
+            }
         }
     }else{
         [[self sizeCache] addObject:@[].mutableCopy];


### PR DESCRIPTION
add a feature that can calculate the size for index path which is beyond the size cache array's bound.

In my project, the navigationController pop transition need the size of current index path (in "from view controller") which is probably beyond the size cache array's bound(in "to viewcontroller"). I hope it could be useful for you~

thanks for your great job, your project help me a lot
